### PR TITLE
Update pipelines.py

### DIFF
--- a/aspect_based_sentiment_analysis/pipelines.py
+++ b/aspect_based_sentiment_analysis/pipelines.py
@@ -276,7 +276,7 @@ class BertPipeline(Pipeline):
         encoded = self.tokenizer.batch_encode_plus(
             token_pairs,
             add_special_tokens=True,
-            pad_to_max_length='right',
+            padding=True,
             return_tensors='tf'
         )
         batch = InputBatch(


### PR DESCRIPTION
Fix FutureWarning from huggingface transformers project: ```FutureWarning: The `pad_to_max_length` argument is deprecated ```, the pad_to_max_length is not used anymore and the huggingface project tells us to make use of padding now which can have the values:

- True (longest sequence)
- 'max-length' (length specified by extra argument max-length)
- False

since pad_to_max_length='right' was used before, it seems alright to make use of just padding=True here, I tested it on my code and it seemed to work just fine.
 

