### PR TITLE
Unfix Python version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Aspect-Based-Sentiment-Analysis
 dependencies:
-  - python=3.7
+  - python>=3.7
   - scikit-learn=0.24.2
   - pytest=6.2.4
   - pytest-timeout=1.4.2

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'optuna',
         'spacy'
     ],
-    python_requires='==3.7.*',
+    python_requires='>=3.7.*',
 )


### PR DESCRIPTION
# Main contribution
The Python version was previously pinned to `3.7`. This PR unfixes the Python version to allow compatibility with later versions of Python as well.

This PR is in response to [this issue](https://github.com/ScalaConsultants/Aspect-Based-Sentiment-Analysis/issues/59).